### PR TITLE
Bump gitleaks from 8.22.1 to 8.23.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: detect-secrets
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.22.1
+    rev: v8.23.1
     hooks:
       - id: gitleaks
   - repo: https://github.com/fabasoad/pre-commit-grype

--- a/README.md
+++ b/README.md
@@ -285,4 +285,4 @@ repos:
 
 ## Contributions
 
-<!-- TODO: -->
+![Alt](https://repobeats.axiom.co/api/embed/3679a9d55b33e5a729c6ae0dad36f4f5fd57d2ca.svg "Repobeats analytics image")

--- a/src/lib/base/checkstyle-common.sh
+++ b/src/lib/base/checkstyle-common.sh
@@ -7,6 +7,8 @@ checkstyle_common() {
   # Removing trailing space (sed command) is needed here in case there were no
   # --checkstyle-args passed, so that $1 in this case is "scan . "
   checkstyle_args="$(echo "${2}" | sed 's/ *$//')"
+  # Exclude cache root directory
+  checkstyle_args="${checkstyle_args} --exclude=.fabasoad"
 
   # Install checkstyle
   checkstyle_path="$(install_checkstyle "${PRE_COMMIT_CHECKSTYLE_CHECKSTYLE_VERSION}")"


### PR DESCRIPTION
### Description

- Bump gitleaks from 8.22.1 to 8.23.1
- Exclude `.fabasoad` from the scanning
- Add "Contributions" to README